### PR TITLE
feat: category metadata in completing-read interfaces

### DIFF
--- a/related-files.el
+++ b/related-files.el
@@ -429,7 +429,17 @@ user."
      for entity in entities
      for entity-string in entity-strings
      do (puthash entity-string entity entity-string-to-entity))
-    (when-let* ((entity-string (completing-read prompt entity-strings nil t)))
+    (when-let* ((entity-table (lambda (str pred flag)
+				(pcase flag
+				  ('nil (try-completion str entity-strings pred))
+				  ('t (all-completions str entity-strings pred))
+				  ('lambda (test-completion str entity-strings pred))
+				  ((and (pred consp)
+					(app car 'boundaries))
+				   `(boundaries 0 . ,(length (cdr flag))))
+				  ('metadata
+				   `(metadata (category . file))))))
+		(entity-string (completing-read prompt entity-table nil t)))
       (gethash entity-string entity-string-to-entity))))
 
 (defun related-files-add-jumper-type (customization-type)


### PR DESCRIPTION
At the moment, all places supported by this package are files. The presented list of places (files) to jump to is just a list of strings (as in, there is no file metadata, so things like Marginalia don't work properly). I think this should be fixed.

---

This might also make it easier to implement [different kinds of jumpers](https://github.com/DamienCassou/related-files/issues/6); have an alist of `(CATEGORY . JUMP-FUNCTION)` function pairs. Whenever the user selects something from the jump list, get its category, look that up, and then `(funcall JUMP-FUNCTION SELECTION)`. Ideally, any such system should also support pretty-printing functions for non-string (e.g. org-roam nodes) places. Just a thought, I don't know how easy this would be to implement.