### PR TITLE
feat: support jumping from non-file-based buffers (e.g. org capture)

### DIFF
--- a/related-files-buffer.el
+++ b/related-files-buffer.el
@@ -23,7 +23,8 @@
 
 ;;; Commentary:
 
-;; Provide buffers as a type of place for `related-files.el'.
+;; Provide buffers as a type of place for `related-files.el'.  A
+;; buffer-based place is the buffer.
 
 ;;; Code:
 
@@ -41,19 +42,21 @@
   "Call `switch-to-buffer' on PLACE."
   (switch-to-buffer place))
 
+(defvar-local related-files-buffer--jumper nil
+  "Remember which jumper was used to reach the current buffer.")
+
 ;;;###autoload
 (cl-defmethod related-files-attach-jumper-to-place (jumper (place buffer))
   "Set `related-files-jumper' to JUMPER, locally in PLACE."
   (with-current-buffer place
-    (setq-local related-files-jumper jumper))
+    (setq-local related-files-buffer--jumper jumper))
   place)
 
 ;;;###autoload
 (cl-defmethod related-files-retrieve-jumper-from-place ((place buffer))
   "Get the value of `related-files-jumper' in PLACE."
-  (defvar related-files-jumper)
   (with-current-buffer place
-    related-files-jumper))
+    related-files-buffer--jumper))
 
 ;;;###autoload
 (cl-defmethod related-files-format-place (_initial-places (place buffer) &optional _annotate)

--- a/related-files-buffer.el
+++ b/related-files-buffer.el
@@ -1,0 +1,66 @@
+;;; related-files-buffer.el --- Add support for buffer-based places to related-files  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2023  Hugo Heagren
+
+;; Author: Hugo Heagren <hugo@undertown>
+;; Package-Requires: ((emacs "28.2"))
+;; Version: 1.0
+;; Keywords: convenience
+;; URL: https://www.gnu.org/software/emacs/
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Provide buffers as a type of place for `related-files.el'.
+
+;;; Code:
+
+(require 'cl-lib)
+
+
+
+;;;###autoload
+(cl-defmethod related-files-place-exists-p ((place buffer))
+  "Call `buffer-live-p' on PLACE."
+  (buffer-live-p place))
+
+;;;###autoload
+(cl-defmethod related-files-goto-place ((place buffer))
+  "Call `switch-to-buffer' on PLACE."
+  (switch-to-buffer place))
+
+;;;###autoload
+(cl-defmethod related-files-attach-jumper-to-place (jumper (place buffer))
+  "Set `related-files-jumper' to JUMPER, locally in PLACE."
+  (with-current-buffer place
+    (setq-local related-files-jumper jumper))
+  place)
+
+;;;###autoload
+(cl-defmethod related-files-retrieve-jumper-from-place ((place buffer))
+  "Get the value of `related-files-jumper' in PLACE."
+  (defvar related-files-jumper)
+  (with-current-buffer place
+    related-files-jumper))
+
+;;;###autoload
+(cl-defmethod related-files-format-place (_initial-places (place buffer) &optional _annotate)
+  "Call `buffer-name' on PLACE.
+
+Ignore INITIAL-PLACES and ANNOTATE."
+  (buffer-name place))
+
+(provide 'related-files-buffer)
+;;; related-files-buffer.el ends here

--- a/related-files-file.el
+++ b/related-files-file.el
@@ -23,7 +23,8 @@
 
 ;;; Commentary:
 
-;; Provide methods or the `related-files' public API for PLACEs as files.
+;; Provide methods for the `related-files' public API for PLACEs as
+;; files.  A file-based place is a string containing the path to the file.
 
 ;;; Code:
 

--- a/related-files-file.el
+++ b/related-files-file.el
@@ -1,0 +1,65 @@
+;;; related-files-file.el --- Add support for file-based places to related-files  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2023  Hugo Heagren
+
+;; Author: Hugo Heagren <hugo@undertown>
+;; Package-Requires: ((emacs "28.2"))
+;; Version: 1.0
+;; Keywords: files
+;; URL: https://www.gnu.org/software/emacs/
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Provide methods or the `related-files' public API for PLACEs as files.
+
+;;; Code:
+
+(require 'cl-lib)
+
+
+
+;;;###autoload
+(cl-defmethod related-files-place-exists-p ((place string))
+  "Call `file-exists-p' on PLACE."
+  (file-exists-p place))
+
+;;;###autoload
+(cl-defmethod related-files-goto-place ((place string))
+  "Call `find-file' on PLACE."
+  (find-file place))
+
+;;;###autoload
+(cl-defmethod related-files-attach-jumper-to-place (jumper (place string))
+  "Set PLACE :related-files-jumper property to JUMPER."
+  (propertize place :related-files-jumper jumper))
+
+;;;###autoload
+(cl-defmethod related-files-retrieve-jumper-from-place ((place string))
+  "Get value of :related-files-jumper text property in PLACE."
+  (get-text-property 0 :related-files-jumper place))
+
+;;;###autoload
+(cl-defmethod related-files-format-place (initial-places (place string) &optional _annotate)
+  "Format PLACE relative to the first string in INITIAL-PLACES.
+
+If INITIAL-PLACES contains no strings, just return PLACE."
+  (if-let ((initial-file (seq-find #'stringp initial-places))
+	   (initial-directory (file-name-directory initial-file)))
+      (file-relative-name place initial-directory)
+    place))
+
+(provide 'related-files-file)
+;;; related-files-file.el ends here

--- a/related-files-recipe.el
+++ b/related-files-recipe.el
@@ -36,7 +36,7 @@
 
 ;;; Overrides of Public Methods
 
-(cl-defmethod related-files-apply ((jumper (head recipe)) place)
+(cl-defmethod related-files-apply ((jumper (head recipe)) (place string))
   "Return a list of new places built by applying recipe JUMPER to PLACE."
   (append
    (apply #'related-files-recipe--apply-filename-jumper place (cdr jumper))

--- a/related-files.el
+++ b/related-files.el
@@ -159,12 +159,38 @@ MANUAL (TODO)."
   :type '(repeat :tag "Jumpers" related-files-jumper)
   :safe (lambda (jumpers) (seq-every-p (lambda (jumper) (eq 'safe (run-hook-with-args-until-success 'related-files-jumper-safety-functions jumper))) jumpers)))
 
+;;;###autoload
+(defcustom related-files-current-place-finders '(buffer-file-name
+						 current-buffer)
+  "List of functions returning the current place.
+
+Each function should return the current place in a different
+form, or nil if called when the function is not applicable to the
+current context (e.g., the function `buffer-file-name' returns
+nil when the current buffer is not associated with a file)."
+  :group 'related-files
+  :type '(repeat function))
+
+(defcustom related-files-place-category-tests
+  '(((pred stringp) 'file)
+    ((pred bufferp) 'buffer))
+  "List of tests for getting type of a place.
+
+This variable is passed as an argument list to `pcase', so must
+take the relevant form.  The return value of each clause must be a
+symbol for a category.  See info node `(elisp)Programmed
+Completion' for more information.  The customization type is an
+approximation of this."
+  :type '(repeat (list (choice symbol integer string cons sexp)
+		       symbol))
+  :group 'related-files)
+
 
 ;;; Public Functions
 
 ;;;###autoload
-(defun related-files-jump (&optional jumpers current-place)
-  "Let the user choose where to go from CURRENT-PLACE by asking JUMPERS.
+(defun related-files-jump (&optional jumpers current-places)
+  "Let the user choose where to go from the current place by asking JUMPERS.
 
 Each element of JUMPERS is asked for a list of candidates and the
 resulting lists are concatenated with duplicates removed.  The
@@ -174,23 +200,25 @@ error message with some ideas on what to configure to get
 candidates.  If the resulting list contains only one item, this
 item is automatically selected.
 
-Only existing files are presented to the user.  Look at
-`related-files-make' and `related-files-jump-or-make' if you also want to be
-able to create new files.
+Only existing places are presented to the user.  Look at
+`related-files-make' and `related-files-jump-or-make' if you also
+want to be able to create new places.
 
 If JUMPERS is not provided, use `related-files-jumpers'.  If
-CURRENT-PLACE is not provided, use the function
-`buffer-file-name'.
+CURRENT-PLACES is not provided, try different places from
+`related-files-current-place-finders'.
 
 Interactively, a numeric prefix argument selects the jumper at
-the specified position (zero-based index) in `related-files-jumpers'."
+the specified position (zero-based index) in
+`related-files-jumpers'."
   (interactive (list (when (numberp current-prefix-arg)
                        (list (seq-elt related-files-jumpers current-prefix-arg)))))
-  (related-files--jump-or-make jumpers current-place :include-existing-places t))
+  
+  (related-files--jump-or-make jumpers current-places :include-existing-places t))
 
 ;;;###autoload
-(defun related-files-make (&optional jumpers current-place)
-  "Let the user choose where to go from CURRENT-PLACE by asking JUMPERS.
+(defun related-files-make (&optional jumpers current-places)
+  "Let the user choose where to go from the current place by asking JUMPERS.
 
 Each element of JUMPERS is asked for a list of candidates and the
 resulting lists are concatenated with duplicates removed.  The
@@ -200,25 +228,25 @@ error message with some ideas on what to configure to get
 candidates.  If the resulting list contains only one item, this
 item is automatically selected.
 
-Only non-existing files are presented to the user so the user can
-easily create them.  This is useful to create a test file for the
-current file for example.  Look at `related-files-jump' and
-`related-files-jump-or-make' if you also want to be able to jump to
-existing files.
+Only non-existing places are presented to the user so the user
+can easily create them.  This is useful to create a test file for
+the current file for example.  Look at `related-files-jump' and
+`related-files-jump-or-make' if you also want to be able to jump
+to existing places.
 
 If JUMPERS is not provided, use `related-files-jumpers'.  If
-CURRENT-PLACE is not provided, use the function
-`buffer-file-name'.
+CURRENT-PLACES is not provided, use
+`related-files-current-place-finders'.
 
 Interactively, a numeric prefix argument selects the jumper at
 the specified position (zero-based index) in `related-files-jumpers'."
   (interactive (list (when (numberp current-prefix-arg)
                        (list (seq-elt related-files-jumpers current-prefix-arg)))))
-  (related-files--jump-or-make jumpers current-place :include-non-existing-places t))
+  (related-files--jump-or-make jumpers current-places :include-non-existing-places t))
 
 ;;;###autoload
-(defun related-files-jump-or-make (&optional jumpers current-place)
-  "Let the user choose where to go from CURRENT-PLACE by asking JUMPERS.
+(defun related-files-jump-or-make (&optional jumpers current-places)
+  "Let the user choose where to go from the current place by asking JUMPERS.
 
 Each element of JUMPERS is asked for a list of candidates and the
 resulting lists are concatenated with duplicates removed.  The
@@ -228,40 +256,82 @@ error message with some ideas on what to configure to get
 candidates.  If the resulting list contains only one item, this
 item is automatically selected.
 
-Both existing and non-existing files are presented to the user so
-the user can easily jump to existing files or create missing
-ones.  Look at `related-files-jump' and `related-files-make' if you don't
-want to mix existing and non-existing files in the same list..
+Both existing and non-existing places are presented to the user
+so the user can easily jump to existing files or create missing
+ones.  Look at `related-files-jump' and `related-files-make' if
+you don't want to mix existing and non-existing files in the same
+list.
 
 If JUMPERS is not provided, use `related-files-jumpers'.  If
-CURRENT-PLACE is not provided, use the function
-`buffer-file-name'.
+CURRENT-PLACES is not provided, use
+`related-files-current-place-finders'.
 
 Interactively, a numeric prefix argument selects the jumper at
 the specified position (zero-based index) in `related-files-jumpers'."
   (interactive (list (when (numberp current-prefix-arg)
                        (list (seq-elt related-files-jumpers current-prefix-arg)))))
-  (related-files--jump-or-make jumpers current-place
+  (related-files--jump-or-make jumpers current-places
                          :include-existing-places t
                          :include-non-existing-places t))
 
 
-;;; Jumpers Public API
+;;; Jumpers and Places Public API
 
-(cl-defgeneric related-files-apply (jumper place)
+(cl-defgeneric related-files-apply (_jumper _place)
   "Apply JUMPER to PLACE and return related places or nil.
 
-PLACE is a filename and the result must be a possibly-empty list
-of filenames.
+PLACE can be anything supported by the methods defined for the
+generic API.  By default methods are provided for
+filenames (strings).  The result must be a possibly-empty list of
+filenames.
 
-The default implementation allows JUMPER to be a function.  The
-function can return either a single place or a possibly-empty
-list of places."
+The generic implementation just returns nil.  This ensures that
+calling a jumper/place pair for which there is no appropriately
+typed method does not break anything -- it just doesn't return
+any places."
+  nil)
+
+(cl-defmethod related-files-apply ((jumper symbol) place)
+"Call JUMPER on PLACE."
   (funcall jumper place))
 
 (cl-defgeneric related-files-get-filler (jumper)
-  "Return a filler associated with JUMPER."
+  "Return a filler associated with JUMPER.")
+
+(cl-defmethod related-files-get-filler ((jumper symbol))
+  "`get' JUMPER's property `related-files-filler'."
   (get jumper 'related-files-filler))
+
+(cl-defgeneric related-files-place-exists-p (_place)
+  "Return non-nil if PLACE exists.
+
+The default implementation returns nil.  This means that related-
+files assumes any place without an appropriate method does not
+exist."
+  nil)
+
+(cl-defgeneric related-files-goto-place (place)
+  "Go to an existing PLACE.")
+
+(cl-defgeneric related-files-attach-jumper-to-place (jumper place)
+  "Attach JUMPER to PLACE.
+
+Return the modified version of PLACE.")
+
+(cl-defgeneric related-files-retrieve-jumper-from-place (place)
+  "Retrieve jumper attached to PLACE.")
+
+(cl-defgeneric related-files-format-place (_initial-places place &optional _annotate)
+  "Format PLACE, relative to INITIAL-PLACES.
+
+If ANNOTATE is non-nil, it is ok for this function to return an
+`annotated' or `decorated' version of PLACE (with extra
+information).  If ANNOTATE is nil,a `bare' version must be
+returned.
+
+The default implementation ignores INITIAL-PLACES and ANNOTATE,
+and prints PLACE with `format'."
+  (format "%s" place))
 
 
 ;;; Filler Public API
@@ -277,44 +347,65 @@ Beyond the filler, this function is called with the :jumper and
 
 ;;; Functions Manipulating Places
 
-(defun related-files--choose-place (places initial-place)
+(defun related-files--get-current-places ()
+  "Return a list of different forms of the current place."
+  (delete-dups
+   (seq-remove
+    #'null
+    (mapcar #'funcall related-files-current-place-finders))))
+
+(defun related-files--choose-place (places initial-places)
   "Let the user pick one of PLACES and return it.
 
-PLACES is a list of filenames and INITIAL-PLACE is a filename.
+PLACES is a list of filenames and INITIAL-PLACES is a list of
+places.
 
 INITIAL-PLACE is the place that was current when the user started
 related-files.  It is used to format each place in PLACES."
   (cond
    ((length= places 0) (user-error "No place to go to.  Consider configuring `related-files-jumpers' or using `related-files-make'") nil)
    ((length= places 1) (car places))
-   (t (let ((initial-directory (file-name-directory initial-place)))
-        (related-files--completing-read "Place: " places (apply-partially #'related-files--format-place initial-directory))))))
+   (t (related-files--completing-read "Place: " places (apply-partially #'related-files--format-place initial-places)))))
 
 (defun related-files--act-on-place (place)
   "Either open or create PLACE, a filename."
-  (if (file-exists-p place)
-      (find-file place)
+  (if (related-files-place-exists-p place)
+      (related-files-goto-place place)
     (related-files--make-place place)))
 
-(defun related-files--format-place (initial-directory place)
+(defun related-files--get-place-category (place)
+  "Get completion category for PLACE.
+
+Use `pcase' to check PLACE against the patterns in
+`related-files-place-category-tests'.  If none succeed, return
+`type-of' PLACE."
+  (eval
+   `(pcase ,place
+      ,@related-files-place-category-tests
+      (_ (type-of ,place)))))
+
+(defun related-files--format-place (initial-places place &optional annotate)
   "Return a string representing PLACE.
 
-INITIAL-DIRECTORY is used to format PLACE relatively.
+INITIAL-PLACES is a list different objects, each representing the
+initial place in a different way (e.g. a filename, a buffer
+object, etc.). It is used to format PLACE relatively.
 
-If PLACE doesn't exist, append \"(create it!)\" to the return
-value."
-  (when-let* ((relative-name (file-relative-name place initial-directory)))
-    (if (file-exists-p place)
-        relative-name
-      (format "%s (create it!)" relative-name))))
+If PLACE doesn't exist (as determined by
+`related-files-place-exists-p'), append \"(create it!)\" to the
+return value."
+  (when-let* ((name (related-files-format-place initial-places place annotate)))
+    (if (or (not annotate) (related-files-place-exists-p place))
+        name
+      (format "%s (create it!)" name))))
 
 (defun related-files--make-place (place)
   "Create the file at PLACE.
 
 If a jumper is attached to PLACE and if this jumper has a filler,
 use the filler to populate the new file with initial content."
-  (find-file place)
-  (when-let* ((jumper (get-text-property 0 :related-files-jumper place))
+  (related-files-goto-place place)
+  (when-let* ((jumper (related-files-retrieve-jumper-from-place place))
               (filler (related-files-get-filler jumper)))
     (related-files-fill filler :jumper jumper :place place)))
 
@@ -341,65 +432,69 @@ use the filler to populate the new file with initial content."
 
 ;;; Utility Functions
 
-(cl-defun related-files--jump-or-make (jumpers current-place &key include-existing-places include-non-existing-places)
-  "Let the user choose where to go from CURRENT-PLACE by asking JUMPERS.
+(cl-defun related-files--jump-or-make (jumpers current-places &key include-existing-places include-non-existing-places)
+  "Let the user choose where to go from the current-place by asking JUMPERS.
 
 Existing files are presented to the user if
 INCLUDE-EXISTING-PLACES is non-nil.  Non-existing files are
 presented to the user if INCLUDE-NON-EXISTING-PLACES is non-nil.
 
 If JUMPERS is not provided, use `related-files-jumpers'.  If
-CURRENT-PLACE is not provided, use the function
-`buffer-file-name'."
+CURRENT-PLACES is not provided, use `related-files-current-place-finders'."
   (let* ((jumpers (or jumpers related-files-jumpers))
-         (current-place (or current-place (buffer-file-name))))
+         (current-places (or current-places (related-files--get-current-places))))
     (cond ((not jumpers)
            (user-error "No jumpers.  Consider configuring `related-files-jumpers'"))
-          ((not current-place)
+          ((not current-places)
            (user-error "Related-Files only works from file-based buffers"))
           (t
            (let ((existing-places (when include-existing-places
-                                    (related-files--collect-existing-places jumpers current-place)))
+                                    (related-files--collect-existing-places jumpers current-places)))
                  (non-existing-places (when include-non-existing-places
-                                        (related-files--collect-non-existing-places jumpers current-place))))
-             (when-let* ((place (related-files--choose-place (append existing-places non-existing-places) current-place)))
+                                        (related-files--collect-non-existing-places jumpers current-places))))
+             (when-let* ((place (related-files--choose-place (append existing-places non-existing-places) current-places)))
                (related-files--act-on-place place)))))))
 
-(defun related-files--collect-existing-places (jumpers current-place)
-  "Return a list of places that can be accessed from CURRENT-PLACE with JUMPERS.
+(defun related-files--collect-existing-places (jumpers current-places)
+  "Return a list of places that can accessible from the current place with JUMPERS.
 
-Each jumper in JUMPERS is not only called with CURRENT-PLACE as
-argument but also with all places generated by other jumpers,
-recursively.  Only existing places are considered and returned.
+Each jumper in JUMPERS is not only called with each element of
+CURRENT-PLACES as argument but also with all places generated by
+other jumpers, recursively.  Only existing places are considered
+and returned.
 
 The returned value doesn't contain CURRENT-PLACE."
-  (when current-place
+  (when current-places
     (let* ((places-result nil)
            (places-tried nil)
-           (places-queue (list current-place)))
+           (places-queue (copy-sequence current-places)))
       (while places-queue
         (when-let* ((place (pop places-queue))
-                    ((file-exists-p place))
+		    ((related-files-place-exists-p place))
                     ((not (seq-contains-p places-tried place))))
-          (unless (equal place current-place) (push place places-result))
-          (let ((new-places (related-files--call-jumpers jumpers place)))
+          (unless (member place current-places) (push place places-result))
+          (let ((new-places (related-files--call-jumpers jumpers `(,place))))
             (push place places-tried)
             (setq places-queue (nconc places-queue new-places)))))
       places-result)))
 
-(defun related-files--collect-non-existing-places (jumpers current-place)
-  "Return a list of places that can be accessed from CURRENT-PLACE with JUMPERS.
+(defun related-files--collect-non-existing-places (jumpers current-places)
+  "Return a list of places accessible from the current place with JUMPERS.
 
 Only non-existing places are considered and returned.  The
-returned value doesn't contain CURRENT-PLACE."
+returned value doesn't contain any places in CURRENT-PLACES."
   (cl-delete-if
-   (lambda (place) (or (equal place current-place)
-                       (file-exists-p place)))
-   (related-files--call-jumpers jumpers current-place)))
+   (lambda (place) (or (member place current-places)
+                       (related-files-place-exists-p place)))
+   (related-files--call-jumpers jumpers current-places)))
 
-(defun related-files--call-jumpers (jumpers place)
-  "Return a list of places that can be accessed from PLACE with JUMPERS."
-  (mapcan (apply-partially #'related-files--call-jumper place) jumpers))
+(defun related-files--call-jumpers (jumpers places)
+  "Return a list of places that can be accessed from PLACES with JUMPERS."
+  (mapcan (lambda (place)
+	    (mapcan
+	     (apply-partially #'related-files--call-jumper place)
+	     jumpers))
+	  places))
 
 (defun related-files--call-jumper (place jumper)
   "Return a list of places that can be accessed from PLACE with JUMPER."
@@ -414,17 +509,32 @@ returned value doesn't contain CURRENT-PLACE."
 
 Each item of the return value remembers it was created with
 JUMPER."
-  (mapcar
-   (lambda (place) (propertize place :related-files-jumper jumper))
-   places))
+  (mapcar (apply-partially #'related-files-attach-jumper-to-place jumper) places))
 
 (defun related-files--completing-read (prompt entities formatter)
   "Display PROMPT and let the user choose one of ENTITIES in the minibuffer.
 
-Format each entity with FORMATTER before presenting it to the
-user."
+FORMATTER is a function for formating ENTITIES.  It should return
+a string for presentation to the user.  It takes one entity, and
+one optional argument ANNOTATE.  If ANNOTATE is non-nil, it is
+acceptable (though not necessary) to return a string with
+annotations or `decorations'.  It ANNOTATE is nil, only a `bare'
+version should be returned.
+
+Before being presented to the user, each entity is formatted by
+FORMATTER with ANNOTATE set to t, then the result has a property
+`multi-category' attached.  The value of this property is a cons
+cell: its car is the category of the entity (as determined by
+`related-files--get-place-category') and its cdr is the string
+returned by FORMATTER when ANNOTATE is nil."
   (let* ((entity-string-to-entity (make-hash-table :test 'equal :size (length entities)))
-         (entity-strings (mapcar formatter entities)))
+	 (format-function
+	  (lambda (entity) (propertize
+		       (funcall formatter entity 'annotate)
+		       'multi-category
+		       (cons (related-files--get-place-category entity)
+			     (funcall formatter entity)))))
+         (entity-strings (mapcar format-function entities)))
     (cl-loop
      for entity in entities
      for entity-string in entity-strings
@@ -438,7 +548,7 @@ user."
 					(app car 'boundaries))
 				   `(boundaries 0 . ,(length (cdr flag))))
 				  ('metadata
-				   `(metadata (category . file))))))
+				   `(metadata (category . multi-category))))))
 		(entity-string (completing-read prompt entity-table nil t)))
       (gethash entity-string entity-string-to-entity))))
 

--- a/related-files.el
+++ b/related-files.el
@@ -161,7 +161,7 @@ MANUAL (TODO)."
 
 ;;;###autoload
 (defcustom related-files-current-place-finders '(buffer-file-name
-						 current-buffer)
+                                                 current-buffer)
   "List of functions returning the current place.
 
 Each function should return the current place in a different
@@ -182,7 +182,7 @@ symbol for a category.  See info node `(elisp)Programmed
 Completion' for more information.  The customization type is an
 approximation of this."
   :type '(repeat (list (choice symbol integer string cons sexp)
-		       symbol))
+                       symbol))
   :group 'related-files)
 
 
@@ -213,7 +213,7 @@ the specified position (zero-based index) in
 `related-files-jumpers'."
   (interactive (list (when (numberp current-prefix-arg)
                        (list (seq-elt related-files-jumpers current-prefix-arg)))))
-  
+
   (related-files--jump-or-make jumpers current-places :include-existing-places t))
 
 ;;;###autoload
@@ -470,7 +470,7 @@ The returned value doesn't contain CURRENT-PLACE."
            (places-queue (copy-sequence current-places)))
       (while places-queue
         (when-let* ((place (pop places-queue))
-		    ((related-files-place-exists-p place))
+                    ((related-files-place-exists-p place))
                     ((not (seq-contains-p places-tried place))))
           (unless (member place current-places) (push place places-result))
           (let ((new-places (related-files--call-jumpers jumpers `(,place))))
@@ -491,10 +491,10 @@ returned value doesn't contain any places in CURRENT-PLACES."
 (defun related-files--call-jumpers (jumpers places)
   "Return a list of places that can be accessed from PLACES with JUMPERS."
   (mapcan (lambda (place)
-	    (mapcan
-	     (apply-partially #'related-files--call-jumper place)
-	     jumpers))
-	  places))
+            (mapcan
+             (apply-partially #'related-files--call-jumper place)
+             jumpers))
+          places))
 
 (defun related-files--call-jumper (place jumper)
   "Return a list of places that can be accessed from PLACE with JUMPER."
@@ -528,28 +528,28 @@ cell: its car is the category of the entity (as determined by
 `related-files--get-place-category') and its cdr is the string
 returned by FORMATTER when ANNOTATE is nil."
   (let* ((entity-string-to-entity (make-hash-table :test 'equal :size (length entities)))
-	 (format-function
-	  (lambda (entity) (propertize
-		       (funcall formatter entity 'annotate)
-		       'multi-category
-		       (cons (related-files--get-place-category entity)
-			     (funcall formatter entity)))))
+         (format-function
+          (lambda (entity) (propertize
+                       (funcall formatter entity 'annotate)
+                       'multi-category
+                       (cons (related-files--get-place-category entity)
+                             (funcall formatter entity)))))
          (entity-strings (mapcar format-function entities)))
     (cl-loop
      for entity in entities
      for entity-string in entity-strings
      do (puthash entity-string entity entity-string-to-entity))
     (when-let* ((entity-table (lambda (str pred flag)
-				(pcase flag
-				  ('nil (try-completion str entity-strings pred))
-				  ('t (all-completions str entity-strings pred))
-				  ('lambda (test-completion str entity-strings pred))
-				  ((and (pred consp)
-					(app car 'boundaries))
-				   `(boundaries 0 . ,(length (cdr flag))))
-				  ('metadata
-				   `(metadata (category . multi-category))))))
-		(entity-string (completing-read prompt entity-table nil t)))
+                                (pcase flag
+                                  ('nil (try-completion str entity-strings pred))
+                                  ('t (all-completions str entity-strings pred))
+                                  ('lambda (test-completion str entity-strings pred))
+                                  ((and (pred consp)
+                                        (app car 'boundaries))
+                                   `(boundaries 0 . ,(length (cdr flag))))
+                                  ('metadata
+                                   `(metadata (category . multi-category))))))
+                (entity-string (completing-read prompt entity-table nil t)))
       (gethash entity-string entity-string-to-entity))))
 
 (defun related-files-add-jumper-type (customization-type)

--- a/tests/related-files-test.el
+++ b/tests/related-files-test.el
@@ -27,6 +27,7 @@
 
 ;;; Code:
 (require 'related-files)
+(require 'related-files-file)
 (require 'ert)
 (require 'cl-lib)
 (require 'seq)
@@ -39,14 +40,36 @@
   (should-not (safe-local-variable-p 'related-files-jumpers (list (lambda (place) place)))))
 
 
+;;; Define test jumpers
+
+(defalias 'related-files-test-jumper-identity #'identity)
+
+(defun related-files-test-jumper-const (_place)
+  "Ignore arguments, return symbol place."
+  'place)
+
+(defun related-files-test-jumper-atom (_place)
+  "Return \"/foo\"."
+  "/foo")
+
+(defun related-files-test-jumper-list (_place)
+  "Return (\"/bar1\" \"/bar2\")."
+  '("/bar1" "/bar2"))
+
+(defun related-files-test-jumper-singleton (_place)
+  "Return (\"/baz\")."
+  '("/baz"))
+
+(defalias 'related-files-test-jumper-nil #'ignore)
+
+(defvar related-files-test-jumper-args nil)
+
+
 ;;; Jumpers Public API
 
 (ert-deftest related-files-test-apply-function-jumper ()
-  (let* ((place 'place)
-         (jumperIdentity #'identity)
-         (jumperConst (lambda (_) place)))
-    (should (equal (related-files-apply jumperIdentity "/foo/bar") "/foo/bar"))
-    (should (equal (related-files-apply jumperConst "/foo/bar") place))))
+  (should (equal (related-files-apply 'related-files-test-jumper-identity "/foo/bar") "/foo/bar"))
+  (should (equal (related-files-apply 'related-files-test-jumper-const "/foo/bar") 'place)))
 
 (defun related-files-test-jumper-with-filler (_)
   "A jumper returning a constant place."
@@ -63,9 +86,9 @@
 (ert-deftest related-files-test-format-place ()
   (cl-letf (((symbol-function 'file-exists-p)
              (apply-partially #'equal "/project/foo/exists.el")))
-    (should (equal (related-files--format-place "/project/foo/" "/project/foo/exists.el") "exists.el"))
-    (should (equal (related-files--format-place "/project/bar/" "/project/foo/exists.el") "../foo/exists.el"))
-    (should (equal (related-files--format-place "/project/foo/" "/project/foo/non-existing.el") "non-existing.el (create it!)"))))
+    (should (equal (related-files--format-place '("/project/foo/") "/project/foo/exists.el") "exists.el"))
+    (should (equal (related-files--format-place '("/project/bar/") "/project/foo/exists.el") "../foo/exists.el"))
+    (should (equal (related-files--format-place '("/project/foo/") "/project/foo/non-existing.el" 'annotate) "non-existing.el (create it!)"))))
 
 
 ;;; Utility Functions
@@ -73,71 +96,74 @@
 (ert-deftest related-files-test-collect-existing-places-does-not-return-current-place ()
   (cl-letf (((symbol-function 'file-exists-p)
              (apply-partially #'seq-contains-p '("/bar" "/foo"))))
-    (let* ((current-place "/bar")
-           (new-place "/foo")
-           (jumper1 (lambda (_) new-place)))
+    (let ((current-place "/bar"))
       (should (equal
-               (related-files--collect-existing-places (list jumper1) current-place)
-               (list new-place))))))
+               (related-files--collect-existing-places '(related-files-test-jumper-atom) `(,current-place))
+               '("/foo"))))))
 
 (ert-deftest related-files-test-collect-existing-places-returns-uniq-results ()
   "If 2 jumpers produce the same place, the place should only appear once."
   (cl-letf (((symbol-function 'file-exists-p)
              (apply-partially #'seq-contains-p '("/bar" "/foo"))))
-    (let* ((current-place "/bar")
-           (new-place "/foo")
-           (jumper1 (lambda (_) new-place))
-           (jumper2 (lambda (_) new-place)))
+    (let ((current-place "/bar"))
       (should (seq-set-equal-p
-               (related-files--collect-existing-places (list jumper1 jumper2) current-place)
-               (list new-place))))))
+               (related-files--collect-existing-places
+		'(related-files-test-jumper-atom related-files-test-jumper-atom)
+		`(,current-place))
+               '("/foo"))))))
 
-(ert-deftest related-files-test-collect-existing-places-avoids-calling-same-jumper-with-current-place-twice ()
-  "A jumper must only be called once per place."
-  (cl-letf (((symbol-function 'file-exists-p) #'identity))
-    (let* ((current-place "/bar")
-           (jumper1-arguments nil)
-           (jumper1 (lambda (place) (push place jumper1-arguments) (list current-place "/place"))))
-      (related-files--collect-existing-places (list jumper1) current-place)
-      (should (seq-set-equal-p
-               jumper1-arguments
-               (list current-place current-place "/place"))))))
+(let ((jumper1-arguments nil)
+      (current-place "/bar"))
+  (defun related-files-test-jumper (place)
+    (push place jumper1-arguments)
+    (list current-place "/place"))
+  (ert-deftest related-files-test-collect-existing-places-avoids-calling-same-jumper-with-current-place-twice ()
+    "A jumper must only be called once per place."
+    (cl-letf (((symbol-function 'file-exists-p) #'identity))
+      (let* ()
+        (related-files--collect-existing-places (list 'related-files-test-jumper) (list current-place))
+        (should (seq-set-equal-p
+                 jumper1-arguments
+                 (list "/place" current-place)))))))
 
 (ert-deftest related-files-test-collect-existing-places-returns-no-place-when-no-current-place ()
   "If there is no current place, there shouldn't be any destination place."
   (should-not (related-files--collect-existing-places '(jumper) nil)))
 
 (ert-deftest related-files-test-call-jumpers ()
-  (let* ((jumperAtom (lambda (_) "/foo"))
-         (jumperList (lambda (_) (list "/bar1" "/bar2")))
-         (jumperSingleton (lambda (_) (list "/baz")))
-         (jumperNil (lambda (_)))
-         (jumperIdentity #'identity))
-    (should (seq-set-equal-p (related-files--call-jumpers
-                              (list jumperAtom jumperList)
-                              "/")
-                             '("/foo" "/bar1" "/bar2")))
-    (should (seq-set-equal-p (related-files--call-jumpers
-                              (list jumperAtom jumperSingleton)
-                              "/")
-                             '("/foo" "/baz")))
-    (should (seq-set-equal-p (related-files--call-jumpers
-                              (list jumperAtom jumperNil)
-                              "/")
-                             '("/foo")))
-    (should (seq-set-equal-p (related-files--call-jumpers
-                              (list jumperAtom jumperIdentity)
-                              '"/")
-                             '("/foo" "/")))
-    (should (seq-set-equal-p (related-files--call-jumpers
-                              (list jumperAtom jumperList jumperSingleton jumperNil jumperIdentity)
-                              '"/")
-                             '("/foo" "/bar1" "/bar2" "/baz" "/")))))
+  (should (seq-set-equal-p (related-files--call-jumpers
+			    '(related-files-test-jumper-atom
+			      related-files-test-jumper-list)
+                            '("/"))
+                           '("/foo" "/bar1" "/bar2")))
+  (should (seq-set-equal-p (related-files--call-jumpers
+			    '(related-files-test-jumper-atom
+			      related-files-test-jumper-singleton)
+			    '("/"))
+			   '("/foo" "/baz")))
+  (should (seq-set-equal-p (related-files--call-jumpers
+			    '(related-files-test-jumper-atom
+			      related-files-test-jumper-nil)
+			    '("/"))
+			   '("/foo")))
+  (should (seq-set-equal-p (related-files--call-jumpers
+			    '(related-files-test-jumper-atom
+			      related-files-test-jumper-identity)
+			    '("/"))
+			   '("/foo" "/")))
+  (should (seq-set-equal-p (related-files--call-jumpers
+			    '(related-files-test-jumper-atom
+			      related-files-test-jumper-singleton
+			      related-files-test-jumper-nil
+			      related-files-test-jumper-identity
+			      related-files-test-jumper-list)
+			    '("/"))
+			   '("/foo" "/bar1" "/bar2" "/baz" "/"))))
 
 (ert-deftest related-files-test-test--call-jumpers-attach-jumper-to-all-places ()
-  (let* ((jumper (lambda (_) "/foo"))
+  (let* ((jumper 'related-files-test-jumper-atom)
          (place (car (related-files--call-jumpers (list jumper) "/"))))
-    (should (eq (get-text-property 0 :related-files-jumper place) jumper))))
+    (should (eq (related-files-retrieve-jumper-from-place place) jumper))))
 
 (provide 'related-files-test)
 ;;; related-files-test.el ends here


### PR DESCRIPTION
The package doesn't work for non-file based buffers, which in particular means it doesn't work in org (roam) capture buffers (for jumping to the pdf I'm making notes on).

I appreciate that you need some sort of reference to get off the ground, and that *normally* that will be a file name, but for my use case it would be great to be able to use other things as well (org roam node id, or a citation ref). Perhaps each jumper could have a parameter which gets the value to use as the jumping "input" or "start". If not present, the paramater could just default to the function `buffer-file-name`.

This would make a big difference to me and my workflows.